### PR TITLE
Feature/refactoring

### DIFF
--- a/src/hooks/useRollbackUnfinishedTransactions.ts
+++ b/src/hooks/useRollbackUnfinishedTransactions.ts
@@ -18,8 +18,9 @@ const useRollbackUnfinishedTransactions = () => {
       !hasCheckedTransactions.current
     ) {
       getUnfinishedOrderData(userInfo.uid)
-        .then(async (orderArray) => {
-          if (orderArray.length) rollbackUnfinishedOrderData(orderArray);
+        .then(async (orderDocuments) => {
+          if (orderDocuments.docs.length)
+            rollbackUnfinishedOrderData(orderDocuments);
         })
         .catch((error) => {
           toast.error('사용자 계정의 구매 정보를 읽어오는데 실패했습니다.', {

--- a/src/pages/buyer/purchase/usePurchase.ts
+++ b/src/pages/buyer/purchase/usePurchase.ts
@@ -4,19 +4,19 @@ import { PurchaseFormData } from '@/types/FormType';
 import { ChangeEventHandler, MouseEventHandler, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useCartItems } from '@/hooks/useCartItems';
-import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
+import { useFirebaseAuth, UserInfo } from '@/hooks/useFirebaseAuth';
 import { toast } from 'sonner';
 import { confirmPayment, processPayment } from '@/services/paymentService';
 import { createPurchaseRegisterObject } from '@/utils/createRegisterObject';
 import {
   fetchProducts,
   purchaseProducts,
-  rollbackPurchaseProducts,
+  rollbackBatchOrder,
 } from '@/services/productService';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { orderBy, where } from 'firebase/firestore';
-import { updateOrderStatus } from '@/services/orderService';
+import { updateBatchOrderStatus } from '@/services/orderService';
 import { OrderStatus } from '@/types/FirebaseType';
 
 const usePurchase = () => {
@@ -50,12 +50,12 @@ const usePurchase = () => {
 
     refetchProductQuantityArray();
 
-    let orderId: string = '';
+    let batchOrderId = '';
 
     try {
-      orderId = await purchaseProducts(
+      batchOrderId = await purchaseProducts(
         items,
-        userInfo!.uid,
+        userInfo as UserInfo,
         `${items[0].productName}${items.length > 1 ? ` 외 ${items.length - 1}건` : ''}`,
       );
 
@@ -64,7 +64,7 @@ const usePurchase = () => {
        */
       const confirmData = await processPayment({
         totalPrice,
-        orderId,
+        orderId: batchOrderId,
         items,
         email: data.buyerEmail,
         name: data.buyerName,
@@ -72,8 +72,8 @@ const usePurchase = () => {
       });
 
       const paymentResultData = await confirmPayment({ confirmData });
-      await updateOrderStatus({
-        orderId,
+      await updateBatchOrderStatus({
+        batchOrderId,
         orderStatus: OrderStatus.OrderCompleted,
       });
 
@@ -90,7 +90,7 @@ const usePurchase = () => {
       else navigate('/');
     } catch (error: unknown) {
       console.log(error);
-      if (orderId) await rollbackPurchaseProducts(items, orderId);
+      if (batchOrderId) await rollbackBatchOrder({ batchOrderId });
       toast.error('구매 도중 에러가 발생했습니다.', {
         description: (error as Error).message,
       });

--- a/src/pages/buyer/purchase/usePurchase.ts
+++ b/src/pages/buyer/purchase/usePurchase.ts
@@ -18,6 +18,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { orderBy, where } from 'firebase/firestore';
 import { updateBatchOrderStatus } from '@/services/orderService';
 import { OrderStatus } from '@/types/FirebaseType';
+import { v4 as uuidv4 } from 'uuid';
 
 const usePurchase = () => {
   const {
@@ -64,7 +65,7 @@ const usePurchase = () => {
        */
       const confirmData = await processPayment({
         totalPrice,
-        orderId: batchOrderId,
+        orderId: uuidv4(),
         items,
         email: data.buyerEmail,
         name: data.buyerName,
@@ -160,6 +161,7 @@ const usePurchase = () => {
 
       return productData;
     },
+    refetchOnMount: 'always',
   });
 
   return {

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -14,15 +14,18 @@ import { buildFirestoreQuery } from '@/utils/firebaseUtils';
 import {
   collection,
   doc,
+  DocumentData,
   getCountFromServer,
   getDocs,
   limit,
   query,
   QueryConstraint,
+  QuerySnapshot,
   runTransaction,
   startAt,
   updateDoc,
   where,
+  writeBatch,
 } from 'firebase/firestore';
 import { toast } from 'sonner';
 
@@ -40,7 +43,7 @@ import { toast } from 'sonner';
  */
 export const getUnfinishedOrderData = async (
   uid: string,
-): Promise<OrderSchema[]> => {
+): Promise<QuerySnapshot<DocumentData, DocumentData>> => {
   const orderDocuments = await getDocs(
     query(
       collection(db, 'order'),
@@ -48,77 +51,60 @@ export const getUnfinishedOrderData = async (
       where('orderStatus', '==', 'OrderCreated'),
     ),
   );
-  const dataArray: OrderSchema[] = orderDocuments.docs.map(
-    (doc) => doc.data() as OrderSchema,
-  );
 
-  console.log(dataArray);
-
-  return dataArray;
+  return orderDocuments;
 };
 
 /**
  * 결제 완료가 되지 않은 주문 정보들을 삭제하고, 상품 수량을 롤백합니다.
  * 삭제는 transaction 을 사용하여 여러 주문 정보를 삭제할 수 있도록 처리합니다.
- * @param orderIdArray 삭제할 주문 레코드의 id가 저장된 배열입니다.
+ * @param orderDocuments 결제가 완료되지 않은 주문 레코드들의 QuerySnapshot 입니다.
  */
 export const rollbackUnfinishedOrderData = async (
-  orderArray: OrderSchema[],
+  orderDocuments: QuerySnapshot<DocumentData, DocumentData>,
 ) => {
+  const orderDataArray: OrderSchema[] = orderDocuments.docs.map(
+    (orderDocument) => orderDocument.data() as OrderSchema,
+  );
+  const productRefs = orderDataArray.map((order) =>
+    doc(db, 'product', order.orderData.id),
+  );
+
   await runTransaction(db, async (transaction) => {
-    const orderRefs = orderArray.map((order) => doc(db, 'order', order.id));
-    const orderSnapshots = await Promise.all(
-      orderRefs.map((ref) => transaction.get(ref)),
+    const productSnapshots = await Promise.all(
+      productRefs.map((ref) => transaction.get(ref)),
     );
 
-    const purchaseErrorInstance = new Error();
+    const errorInstance = new Error();
 
     // 반복문을 사용해 미결제 주문 정보마다 롤백 로직을 수행합니다.
-    // 주문별 상품 정보를 가져올 때 await 를 사용하므로 forEach 대신 for문을 사용합니다.
-    for (let orderIndex = 0; orderIndex < orderSnapshots.length; orderIndex++) {
-      const snapshot = orderSnapshots[orderIndex];
+    productSnapshots.forEach((snapshot, index) => {
       if (!snapshot.exists()) {
-        purchaseErrorInstance.name = 'firebase.store.order.read';
-        purchaseErrorInstance.message = `주문 정보 "${orderArray[orderIndex].orderName}" 를 읽어오는데 실패했습니다.`;
-        throw purchaseErrorInstance;
+        errorInstance.name = 'firebase.store.product.read';
+        errorInstance.message = `상품 "${orderDataArray[index].orderData.productName}" 의 정보를 읽어오는데 실패했습니다.`;
+        throw errorInstance;
       }
 
-      const orderData = snapshot.data() as OrderSchema;
+      const productData = snapshot.data();
 
-      // 주문에 해당하는 상품들을 불러옵니다.
-      const productSnapshots = await Promise.all(
-        orderData.cartItemsArray.map((item) =>
-          transaction.get(doc(db, 'product', item.id)),
-        ),
-      );
-
-      // 각 상품들에 대해 반복문을 수행합니다.
-      productSnapshots.forEach((productSnapshot, productIndex) => {
-        if (!productSnapshot.exists()) {
-          purchaseErrorInstance.name = 'firebase.store.product.read';
-          purchaseErrorInstance.message = `상품 "${orderData.cartItemsArray[productIndex].productName}" 의 정보를 읽어오는데 실패했습니다.`;
-          throw purchaseErrorInstance;
-        }
-        const productData = productSnapshot.data() as ProductSchema;
-
-        // 상품의 재고 정보를 롤백합니다.
-        transaction.update(doc(db, 'product', productData.id), {
-          productQuantity:
-            productData.productQuantity +
-            orderData.cartItemsArray[productIndex].productQuantity,
-          productSalesrate:
-            productData.productSalesrate -
-            orderData.cartItemsArray[productIndex].productQuantity,
-        });
+      transaction.update(productRefs[index], {
+        productQuantity:
+          productData!.productQuantity +
+          orderDataArray[index].orderData.productQuantity,
+        productSalesrate:
+          productData!.productSalesrate -
+          orderDataArray[index].orderData.productQuantity,
       });
 
       // 재고 정보의 롤백을 마친 후 주문 정보를 삭제합니다.
-      transaction.delete(doc(db, 'order', orderData.id));
-    }
+      orderDocuments.forEach((orderDocument) =>
+        transaction.delete(orderDocument.ref),
+      );
+    });
   });
 
   toast.success(
-    `미결제 주문 ${orderArray.length}건의 주문 취소가 완료되었습니다.`,
+    `미결제 주문 ${orderDocuments.docs.length}건의 주문 취소가 완료되었습니다.`,
   );
 };
 
@@ -130,6 +116,27 @@ export const updateOrderStatus = async ({
   orderStatus: OrderStatus;
 }) => {
   await updateDoc(doc(db, 'order', orderId), { orderStatus });
+};
+
+export const updateBatchOrderStatus = async ({
+  batchOrderId,
+  orderStatus,
+}: {
+  batchOrderId: string;
+  orderStatus: OrderStatus;
+}) => {
+  const orderDocuments = await getDocs(
+    buildFirestoreQuery(db, 'order', [
+      where('batchOrderId', '==', batchOrderId),
+    ]),
+  );
+  const batch = writeBatch(db);
+
+  orderDocuments.forEach((orderDocument) => {
+    batch.update(orderDocument.ref, { orderStatus });
+  });
+
+  await batch.commit();
 };
 
 /*

--- a/src/types/FirebaseType.ts
+++ b/src/types/FirebaseType.ts
@@ -55,14 +55,25 @@ export type KoreanOrderStatus =
   | '발송 시작'
   | '주문 취소';
 
+/**
+ * 주문 DB 에 저장될 스키마. 같은 주문에 대해서 각 상품별로 따로 저장되기 때문에
+ * 같은 주문의 각 상품들은 orderId 필드가 같은 값을 가진다.
+ * @property {string} batchOrderId 주문 롤백 시 사용할 조건으로 필요. buyerEmail_isoString 형태(같은 주문끼리 중복가능)
+ * @property {string} buyerId 구매자 id
+ * @property {string} orderName 주문명(Ex. 파란색 티셔츠 외 7건)
+ * @property {CartItem} orderData 주문에 포함된 각 상품 목록.(id 항목을 통해 상품 상페 정보를 불러온다.)
+ * @property {OrderStatus} orderStatus 주문 상태
+ * @property {string} createdAt 생성 날짜
+ * @property {string} updatedAt 수정 날짜
+ */
 export type OrderSchema = {
-  id: string; // 자동 생성된 id
-  buyerId: string; // 구매자 id
-  orderName: string; // 주문명(Ex. 파란색 티셔츠 외 7건)
-  cartItemsArray: CartItem[]; // 주문에 포함된 각 상품 목록.(id 항목을 통해 상품 상페 정보를 불러온다.)
-  orderStatus: OrderStatus; // 주문상태
-  createdAt: string; // 생성 날짜
-  updatedAt: string; // 수정 날짜
+  batchOrderId: string;
+  buyerId: string;
+  orderName: string;
+  orderData: CartItem;
+  orderStatus: OrderStatus;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type QueryDocumentType = QueryDocumentSnapshot<


### PR DESCRIPTION
- 기존 order 스키마는 각 상품들의 판매자가 다른 경우에 주문 상태 변경 로직이 맞지 않는것을 발견
  - 한 주문(order) 레코드 안에 모든 상품 정보가 포함되어 있던 기존 구조 => 각 상품별로 따로 주문 레코드를 생성하도록 스키마 변경
  - 대신 각 상품들을 한 주문으로 구분할 수 있게 batchOrderId 필드 추가
  - 이에 맞게 CRUD 메서드들 중 필요한 경우 batch 용 메서드와 단일 레코드용 메서드로 분리
- useHistory : 데이터 구조화 로직 및 네이밍 수정
- usePurchase : tosspayments-sdk 관련 orderId 값 수정, 구매 페이지 접근 시 재고 데이터 갱신을 위해 refetchOnMount: 'always' 옵션 적용